### PR TITLE
Optimization to cBitmap:flood()

### DIFF
--- a/Tools/com.renoise.cLib.xrnx/cLib/classes/cBitmap.lua
+++ b/Tools/com.renoise.cLib.xrnx/cLib/classes/cBitmap.lua
@@ -63,10 +63,8 @@ function cBitmap:flood(color)
 
   self.pixels = {}
   
-  for row = 1,self.height do
-    for col = 1,self.width do  
-      table.insert(self.pixels,color)
-    end
+  for k = 1,self.height*self.width do
+    self.pixels[k] = color
   end
   
 end


### PR DESCRIPTION
App 1/3 of the previous loop time (possibly significant for heavy/frequent bmp generation).