### PR TITLE
Typo: Looses -> Loses

### DIFF
--- a/Documentation/Renoise.ScriptingTool.API.lua
+++ b/Documentation/Renoise.ScriptingTool.API.lua
@@ -297,7 +297,7 @@ renoise.tool().bundle_path
 renoise.tool().app_became_active_observable
   -> [renoise.Document.Observable object]
 
--- Invoked as soon as the application looses focus and another app
+-- Invoked as soon as the application loses focus and another app
 -- becomes the foreground window.
 renoise.tool().app_resigned_active_observable
   -> [renoise.Document.Observable object]


### PR DESCRIPTION
Error in English found, Looses should be Loses.