### PR TITLE
Duplex: Uncomment param_values code

### DIFF
--- a/Tools/com.renoise.Duplex.xrnx/Duplex/Applications/Effect.lua
+++ b/Tools/com.renoise.Duplex.xrnx/Duplex/Applications/Effect.lua
@@ -1476,10 +1476,12 @@ function Effect:_attach_to_parameters(new_song)
       local param_name = parameter and parameter.name or "-"
       self._param_names[control_index]:set_text(param_name)
     end
-    --if self._param_values and self._param_values[control_index] then
-    --  local param_value = parameter and parameter.value_string or ""
-    --  self._param_values[control_index]:set_text(param_value)
-    --end
+    
+    if self._param_values and self._param_values[control_index] then
+     local param_value = parameter and parameter.value_string or ""
+     self._param_values[control_index]:set_text(param_value)
+    end
+
   end
 
   self.display:apply_tooltips(self.mappings.parameters.group_name)


### PR DESCRIPTION
This adds (back?) functionality to allow parameter display in labels 

Discussed in the forum with @bjorn-nesby https://forum.renoise.com/t/duplex-and-nektar-panorama-controllers/48877/14