### PR TITLE
- Duplex: `safe_line` -> `line_idx`

### DIFF
--- a/Tools/com.renoise.Duplex.xrnx/Duplex/Applications/StepSequencer.lua
+++ b/Tools/com.renoise.Duplex.xrnx/Duplex/Applications/StepSequencer.lua
@@ -1128,7 +1128,7 @@ function StepSequencer:post_jump_update()
 
   if (self.options.follow_line.value == FOLLOW_LINE_SET) then
     local line_idx = self:_get_line_offset()+1
-    xPatternPos.jump_to_line(safe_line)
+    xPatternPos.jump_to_line(line_idx)
   end
 
 end


### PR DESCRIPTION
There is an undeclared variable in Duplex/[StepSequencer](https://github.com/renoise/xrnx/blob/master/Tools/com.renoise.Duplex.xrnx/Docs/Applications/StepSequencer.md). The only way I am able to get the application up and running is by applying the changes from the current PR and the one I made in [xLib](https://github.com/renoise/xLib/pull/1).