### PR TITLE
renoisesong -> renoise.song

### DIFF
--- a/Documentation/Renoise.Song.API.lua
+++ b/Documentation/Renoise.Song.API.lua
@@ -1588,7 +1588,7 @@ renoise.song().instruments[].phrases[].loop_end, _observable
   -> [number, loop_start-number_of_lines]
 
 -- Phrase autoseek settings.
-renoisesong().instruments[].phrases[].autoseek, _observable
+renoise.song().instruments[].phrases[].autoseek, _observable
   -> [boolean]
 
 -- Phrase local lines per beat setting. New phrases get initialized with 


### PR DESCRIPTION
there's a typo, so this PR fixes the issue, from `renoisesong` to `renoise.song`