### PR TITLE
Gridpie: New indicator lights, bugfixes

### DIFF
--- a/Tools/com.renoise.GridPie.xrnx/main.lua
+++ b/Tools/com.renoise.GridPie.xrnx/main.lua
@@ -282,7 +282,10 @@ function toggler(x, y)
   local rns = renoise.song()
   local source = rns.patterns[rns.sequencer:pattern(y)]
   local dest = rns.patterns[GRIDPIE_IDX]
-  if dest == nil then abort() end
+  if dest == nil then
+    abort()
+    return
+  end
   local lc = least_common(dest.number_of_lines, source.number_of_lines)
   local toc = 0
 

--- a/Tools/com.renoise.GridPie.xrnx/main.lua
+++ b/Tools/com.renoise.GridPie.xrnx/main.lua
@@ -282,6 +282,7 @@ function toggler(x, y)
   local rns = renoise.song()
   local source = rns.patterns[rns.sequencer:pattern(y)]
   local dest = rns.patterns[GRIDPIE_IDX]
+  if dest == nil then abort() end
   local lc = least_common(dest.number_of_lines, source.number_of_lines)
   local toc = 0
 
@@ -517,10 +518,10 @@ end
 -- Abort
 --------------------------------------------------------------------------------
 
-function abort(notification)
+function abort()
 
   renoise.app():show_message(
-    "You dun goofed! Grid Pie needs to be restarted."
+    "Unexpected problem! Usually triggered by moving or deleting the special Grid Pie pattern, and Grid Pie needs to be restarted."
   )
   if MY_INTERFACE and MY_INTERFACE.visible then MY_INTERFACE:close() end
 

--- a/Tools/com.renoise.GridPie.xrnx/manifest.xml
+++ b/Tools/com.renoise.GridPie.xrnx/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <RenoiseScriptingTool doc_version="0">
-  <ApiVersion>5</ApiVersion>
+  <ApiVersion>6</ApiVersion>
   <Id>com.renoise.GridPie</Id>
-  <Version>0.92</Version>
+  <Version>1.0</Version>
   <Author>Dac Chartrand [dac@renoise.com]</Author>
   <Name>Grid Pie</Name>
   <Description>Renoise cut and pastry. Live sequence recombinator.</Description>

--- a/Tools/com.renoise.GridPie.xrnx/manifest.xml
+++ b/Tools/com.renoise.GridPie.xrnx/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <RenoiseScriptingTool doc_version="0">
-  <ApiVersion>6</ApiVersion>
+  <ApiVersion>6.1</ApiVersion>
   <Id>com.renoise.GridPie</Id>
   <Version>1.0</Version>
   <Author>Dac Chartrand [dac@renoise.com]</Author>

--- a/Tools/com.renoise.GridPie.xrnx/toolbox.lua
+++ b/Tools/com.renoise.GridPie.xrnx/toolbox.lua
@@ -28,23 +28,6 @@ end
 
 
 --------------------------------------------------------------------------------
--- PHP style exlpode()
---------------------------------------------------------------------------------
-
-function explode(div,str)
-  if (div=='') then return false end
-  local pos,arr = 0,table.create()
-  -- for each divider found
-  for st,sp in function() return string.find(str,div,pos,true) end do
-    table.insert(arr,string.sub(str,pos,st-1)) -- Attach chars left of current divider
-    pos = sp + 1 -- Jump past current divider
-  end
-  table.insert(arr,string.sub(str,pos)) -- Attach chars right of last divider
-  return arr
-end
-
-
---------------------------------------------------------------------------------
 -- OneShotIdle Class
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR:

- Adds new indicator lights.
- Fixes a few bugs
  - Opening a song, selecting a grid, then selecting another grid, would lose track of how to unmute the slots on exit
  -  `insert_new_pattern_at` inserts an unindex pattern, but it does not guarantee that the pattern is empty
  -  explode function never used, removed it

See new Grid Pie tutorial for demo:
https://www.youtube.com/watch?v=bPo8v0SCoSA