### PR TITLE
Duplex: fix, ensure we try to broadcast message within the accepted range

### DIFF
--- a/Tools/com.renoise.Duplex.xrnx/Duplex/Display.lua
+++ b/Tools/com.renoise.Duplex.xrnx/Duplex/Display.lua
@@ -401,7 +401,7 @@ function Display:set_parameter(param,ui_obj,point,skip_ui)
 
       local handle_fader_widget = function()
         widget:remove_notifier(self.ui_notifiers[param.xarg.id])
-        widget.value = tonumber(value)
+        widget.value = math.min(tonumber(value), param.xarg.maximum)
         widget:add_notifier(self.ui_notifiers[param.xarg.id])
       end
 


### PR DESCRIPTION
```text
*** std::logic_error: 'ViewBuilder: invalid value for rotary encoder: '127'. value must be [0 - 127].'
*** stack traceback:
***   [C]: ?
***   [C]: in function '__newindex'
***   [string "do..."]:22: in function <[string "do..."]:9>
***   .\Duplex/Display.lua:404: in function 'handle_fader_widget'
***   .\Duplex/Display.lua:433: in function '?'
***   .\Duplex/Display.lua:443: in function 'set_parameter'
***   .\Duplex/Display.lua:291: in function 'update'
***   .\Duplex/BrowserProcess.lua:727: in function 'on_idle'
***   .\Duplex/Browser.lua:294: in function 'on_idle'
***   main.lua:402: in function <main.lua:400>
```

was getting this stacktrace when Renoise was trying to broadcast midi message when drawing automation on some devices' control (such as volume, send, width)

Despite the message claimed "127", i found out those control were not rounded, and felt beyond the accepted range : 

```
before  
127  << param.xarg.maximum
127.00000762939   << value
```

Using `math.min()`, versus maximum value fixes this for me.