### PR TITLE
feat: (duplex/launchpad_mk3) use modern launchpad sysex instead of the palette

### DIFF
--- a/Tools/com.renoise.Duplex.xrnx/Duplex/Controllers/LaunchpadMiniMK3/Configurations/LaunchPadMiniMK3_GridPieFull.lua
+++ b/Tools/com.renoise.Duplex.xrnx/Duplex/Controllers/LaunchpadMiniMK3/Configurations/LaunchPadMiniMK3_GridPieFull.lua
@@ -21,16 +21,6 @@ duplex_configurations:insert {
 
   applications = {
     GridPie = {
-      palette = {
-        empty = {color=LaunchpadMiniMK3.COLOR_OFF},
-        empty_current = {color=LaunchpadMiniMK3.COLOR_YELLOW},
-        empty_active = {color=LaunchpadMiniMK3.COLOR_MAGENTA},
-        empty_active_current = {color=LaunchpadMiniMK3.COLOR_MAGENTA},
-        content_active = {color=LaunchpadMiniMK3.COLOR_CYAN},
-        content_active_current = {color=LaunchpadMiniMK3.COLOR_CYAN},
-        content_selected = {color=LaunchpadMiniMK3.COLOR_GREEN},
-        inactive_content = {color=LaunchpadMiniMK3.COLOR_BLUE}
-      },
 	    mappings = {
 	      grid = {
           group_name = "Grid",

--- a/Tools/com.renoise.Duplex.xrnx/Duplex/Controllers/LaunchpadMiniMK3/LaunchpadMiniMK3.lua
+++ b/Tools/com.renoise.Duplex.xrnx/Duplex/Controllers/LaunchpadMiniMK3/LaunchpadMiniMK3.lua
@@ -17,25 +17,10 @@ cLib.require(_clibroot.."cTable")
 
 class "LaunchpadMiniMK3" (MidiDevice)
 
-LaunchpadMiniMK3.COLOR_OFF     = {0x00,0x00,0x00}
-LaunchpadMiniMK3.COLOR_WHITE   = {0xff,0xff,0xff}
-LaunchpadMiniMK3.COLOR_GREEN   = {0x00,0xff,0x00}
-LaunchpadMiniMK3.COLOR_YELLOW  = {0xff,0xff,0x00}
-LaunchpadMiniMK3.COLOR_BLUE    = {0x00,0x00,0xff}
-LaunchpadMiniMK3.COLOR_RED     = {0xff,0x00,0x00}
-LaunchpadMiniMK3.COLOR_MAGENTA = {0xff,0x00,0xff}
-LaunchpadMiniMK3.COLOR_CYAN    = {0x00,0xff,0xff}
-
-
 function LaunchpadMiniMK3:__init(display_name, message_stream, port_in, port_out)
-
   MidiDevice.__init(self, display_name, message_stream, port_in, port_out)
-
   self:send_sysex_message(0x00,0x20,0x29,0x02,0x0D,0x0E,0x01)
-
-  -- TODO this device has a full RGB support via the LED lighting SysEx message,
-  -- this is a cheap workaround for now, using the color palette...
-  self.colorspace = {1, 1, 1}
+  self.colorspace = {8 ,8 ,8}
 end
 
 --------------------------------------------------------------------------------
@@ -45,11 +30,8 @@ end
 -- and duty cycle are reset to defaults
 
 function LaunchpadMiniMK3:release()
-
-  -- self:send_cc_message(0,0) 
   self:send_sysex_message(0x00,0x20,0x29,0x02,0x0D,0x0E,0x00)
   MidiDevice.release(self)
-
 end
 
 --------------------------------------------------------------------------------
@@ -60,36 +42,20 @@ end
 function LaunchpadMiniMK3:output_value(pt,xarg,ui_obj)
   if (xarg.type == "button") then
     -- all buttons are colored 
-
     local color = self:quantize_color(pt.color)
-    local rslt = nil
-
-    if cLib.table_compare(color,LaunchpadMiniMK3.COLOR_OFF) then
-      rslt = 0
-    elseif cLib.table_compare(color,LaunchpadMiniMK3.COLOR_WHITE) then
-      rslt = 3
-    elseif cLib.table_compare(color,LaunchpadMiniMK3.COLOR_GREEN) then
-      rslt = 21
-    elseif cLib.table_compare(color,LaunchpadMiniMK3.COLOR_YELLOW) then
-      rslt = 13
-    elseif cLib.table_compare(color,LaunchpadMiniMK3.COLOR_BLUE) then
-      rslt = 45
-    elseif cLib.table_compare(color,LaunchpadMiniMK3.COLOR_RED) then
-      rslt = 5
-    elseif cLib.table_compare(color,LaunchpadMiniMK3.COLOR_MAGENTA) then
-      rslt = 81
-    elseif cLib.table_compare(color,LaunchpadMiniMK3.COLOR_CYAN) then
-      rslt = 37
+    if (xarg.value:sub(1,3) == "CC#") then
+      -- https://userguides.novationmusic.com/hc/en-gb/articles/24001475492498-Controlling-the-Launchpad-X-surface
+      -- (modern launchpads (mini, X, ...) should behave similarly)
+      -- duplex code colors over 8 bits, launchpad support 7.
+      self:send_sysex_message(0, 32, 41, 2, 12, 3, 3, tonumber(xarg.value:sub(4)), color[1] / 2, color[2] / 2, color[3] / 2, 247)
+    else
+      self:send_sysex_message(0, 32, 41, 2, 12, 3, 3, value_to_midi_pitch(xarg.value)+12, color[1] / 2, color[2] / 2, color[3] / 2, 247)
     end
-
-    --print("pt.color",rprint(pt.color))
-    --print("rslt",rslt)
-    --rprint(xarg)
-    return rslt
+    -- return a dummy color, and don't update the hardware knob (we already updated color with sysex)
+    return 0, true
   else
     -- otherwise, echo back
     --print("echo back",rprint(pt),MidiDevice.output_value(self,pt,xarg,ui_obj))
     return MidiDevice.output_value(self,pt,xarg,ui_obj)
   end
 end
-


### PR DESCRIPTION
send out sysex to maintain pad colors, no need to define palettes anymore