### PR TITLE
feat: (duplex/launchpad_mk3) carry compat with launchpad pro mk1 and mk2

### DIFF
--- a/Tools/com.renoise.Duplex.xrnx/Duplex/Controllers/LaunchpadMiniMK3/LaunchpadMiniMK3.lua
+++ b/Tools/com.renoise.Duplex.xrnx/Duplex/Controllers/LaunchpadMiniMK3/LaunchpadMiniMK3.lua
@@ -20,7 +20,7 @@ class "LaunchpadMiniMK3" (MidiDevice)
 function LaunchpadMiniMK3:__init(display_name, message_stream, port_in, port_out)
   MidiDevice.__init(self, display_name, message_stream, port_in, port_out)
   self:send_sysex_message(0x00,0x20,0x29,0x02,0x0D,0x0E,0x01)
-  self.colorspace = {8 ,8 ,8}
+  self.colorspace = {8,8,8}
 end
 
 --------------------------------------------------------------------------------
@@ -40,16 +40,25 @@ end
 -- @see Device.output_value
 
 function LaunchpadMiniMK3:output_value(pt,xarg,ui_obj)
+  -- print(self.port_out)
   if (xarg.type == "button") then
     -- all buttons are colored 
     local color = self:quantize_color(pt.color)
-    if (xarg.value:sub(1,3) == "CC#") then
-      -- https://userguides.novationmusic.com/hc/en-gb/articles/24001475492498-Controlling-the-Launchpad-X-surface
-      -- (modern launchpads (mini, X, ...) should behave similarly)
-      -- duplex code colors over 8 bits, launchpad support 7.
-      self:send_sysex_message(0, 32, 41, 2, 12, 3, 3, tonumber(xarg.value:sub(4)), color[1] / 2, color[2] / 2, color[3] / 2, 247)
+    if (string.match(self.port_out, "Launchpad Pro")) then
+      if (xarg.value:sub(1,3) == "CC#") then
+        self:send_sysex_message(0, 32, 41, 2, 16, 11, tonumber(xarg.value:sub(4)), color[1] / 4, color[2] / 4, color[3] / 4, 247)
+      else
+        self:send_sysex_message(0, 32, 41, 2, 16, 11, value_to_midi_pitch(xarg.value)+12, color[1] / 4, color[2] / 4, color[3] / 4, 247)
+      end
     else
-      self:send_sysex_message(0, 32, 41, 2, 12, 3, 3, value_to_midi_pitch(xarg.value)+12, color[1] / 2, color[2] / 2, color[3] / 2, 247)
+      if (xarg.value:sub(1,3) == "CC#") then
+        -- https://userguides.novationmusic.com/hc/en-gb/articles/24001475492498-Controlling-the-Launchpad-X-surface
+        -- (modern launchpads (mini, X, ...) should behave similarly)
+        -- duplex code colors over 8 bits, launchpad support 7.
+        self:send_sysex_message(0, 32, 41, 2, 12, 3, 3, tonumber(xarg.value:sub(4)), color[1] / 2, color[2] / 2, color[3] / 2, 247)
+      else
+        self:send_sysex_message(0, 32, 41, 2, 12, 3, 3, value_to_midi_pitch(xarg.value)+12, color[1] / 2, color[2] / 2, color[3] / 2, 247)
+      end
     end
     -- return a dummy color, and don't update the hardware knob (we already updated color with sysex)
     return 0, true
@@ -59,3 +68,4 @@ function LaunchpadMiniMK3:output_value(pt,xarg,ui_obj)
     return MidiDevice.output_value(self,pt,xarg,ui_obj)
   end
 end
+


### PR DESCRIPTION
add compatibility for the launchpad pro mk1 and mk2 (mk3 is a bit more complex, and will need an whole new controller code (also i don't have one))

it _could_ be nice to split these to a dedicated controller anyway in order to take advantage for the left and bottom row/col of buttons and RGB.

Also the RGB on legacy pros have a 6 bit (64) per color, with make the dimmed white and white quite close visually.