### PR TITLE
Update Grid Pie for v3.5 (LuaJIT compatibility)

### DIFF
--- a/Tools/com.renoise.GridPie.xrnx/toolbox.lua
+++ b/Tools/com.renoise.GridPie.xrnx/toolbox.lua
@@ -19,6 +19,7 @@ end
 
 -- find least common multiplier with N args
 function least_common(...)
+  local arg = {...}
   local cm = arg[1]
   for i=1,#arg-1,1 do
     cm = lcm(cm,arg[i+1])
@@ -45,7 +46,7 @@ function OneShotIdleNotifier:__init(delay_in_ms, callback, ...)
   assert(type(callback) == "function")
 
   self._callback = callback
-  self._args = arg
+  self._args = {...}
   self._invoke_time = os.clock() + delay_in_ms / 1000
 
   renoise.tool().app_idle_observable:add_notifier(self, self.__on_idle)


### PR DESCRIPTION
Hello! Grid Pie is one of my favorite Renoise tools, but it doesn't work with v3.5, resulting in an error like the one shown here:

<img width="606" height="340" alt="Screenshot From 2026-01-14 19-30-13" src="https://github.com/user-attachments/assets/2ea0d57a-8fca-4478-8675-02fabf6aecf3" />

This happens because Grid Pie uses the implicit `arg` table to access the arguments passed to variadic functions - something LuaJIT (new in Renoise v3.5) does not support, as it is compatible only with the Lua 5.1 syntax. I've added a change to use the table constructor in a couple places to make the tool compatible with LuaJIT.